### PR TITLE
Improve the error message for interleaving octaves

### DIFF
--- a/psiaudio/pipeline.py
+++ b/psiaudio/pipeline.py
@@ -772,7 +772,8 @@ def extract_epochs(fs, queue, epoch_size, target, buffer_size=0,
                 break
 
         if not (queue or epoch_coroutines) and empty_queue_cb:
-            # If queue and epoch coroutines are complete, call queue callback.
+            # If queue and epoch coroutines are complete, call queue callback
+            # once and only once.
             empty_queue_cb()
             empty_queue_cb = None
 

--- a/psiaudio/queue.py
+++ b/psiaudio/queue.py
@@ -361,7 +361,7 @@ class AbstractSignalQueue:
         delay = next(data['delays'])
         self._delay_samples = int(round(delay*self._fs))
         if self._delay_samples < 0:
-            raise ValueError(f'Invalid option for delay. Got {delay}.')
+            raise ValueError(f'Invalid value for ITI interval. Got {delay}.')
 
         t0 = self._t0 + (self._samples/self._fs)
         info = {


### PR DESCRIPTION
The error message now provides some hints to help end-users figure out a solution.
